### PR TITLE
Solution to tip 336

### DIFF
--- a/tips/336.md
+++ b/tips/336.md
@@ -60,4 +60,32 @@ int main() {
 
 </p></details><details><summary>Solutions</summary><p>
 
+```cpp
+template <auto N>
+constexpr auto matmul(v16qi (&A)[N], v16qi (&B)[N], std::int32_t (&C)[N][N]) {
+    static_assert(N <= 16, "Matrices larger than 16x16 are not supported");
+    auto sum = [](const auto &vec) {
+        auto ret = [&vec]<std::size_t... Idxs>(std::index_sequence<Idxs...>) {
+            return (vec[Idxs] + ...);
+        }(std::make_index_sequence<N>{});
+        return ret;
+    };
+    using v64si = std::int32_t [[gnu::vector_size(16 * sizeof(std::int32_t))]];
+    auto get_col = [&B](const auto col_idx) {
+        auto col =
+            [&B, col_idx]<std::size_t... Idxs>(std::index_sequence<Idxs...>) {
+                return v16qi{B[Idxs][col_idx]...};
+            }(std::make_index_sequence<N>{});
+        return __builtin_convertvector(col, v64si);
+    };
+    for (auto i = 0; i < N; ++i) {
+        for (auto j = 0; j < N; ++j) {
+            C[i][j] = sum(__builtin_convertvector(A[i], v64si) * get_col(j));
+        }
+    }
+}
+```
+
+> https://godbolt.org/z/earr7KxK4
+
 </p></details>


### PR DESCRIPTION
This solution assumes we are not allowed to modify existing code in the puzzle. Otherwise I would change the vector underlying type from std::int8_t to std::int32_t so we don't overflow multiplication with int8's.

Another solution could involve copying to a std::valarray<std::int32_t> instead of using __builtin_convertvector()