### PR TITLE
Adds automatic generation of an RSS feed

### DIFF
--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -1,0 +1,36 @@
+name: RSS feed generator
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@master
+        with:
+          ref: master
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - run: pip install -r requirements.txt
+
+      - run: python main.py
+
+      - name: push
+        uses: github-actions-x/commit@v2.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: 'master'
+          commit-message: '[no ci] Update RSS feed'
+          force-add: 'true'
+          files: "*.xml"
+          name: GitHub bot
+          email: noreply@github.com

--- a/feed.template.xml
+++ b/feed.template.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>C++ Tip of The Week</title>
+        <link>https://tip-of-the-week.github.io/cpp/</link>
+        <atom:link rel="self" type="application/rss+xml" href="https://tip-of-the-week.github.io/cpp/feed.xml"/>
+        <language>en</language>
+        <description>Your weekly dose of modern C++ challenge (Release every Sunday).</description>
+        <!-- START FEED -->
+    </channel>
+</rss>
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+markdown

--- a/rss_generator.py
+++ b/rss_generator.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+import re
+import sys
+import glob
+import pathlib
+import datetime
+import markdown
+
+
+def gen_feed(tips, url):
+    date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S GMT")
+    title_re = r"\* +(\*\*)?(?P<title>(?(1).+(?<!\*\*)|.+))(?(1)\*\*$|$)"
+
+    xml = ""
+    for tip in tips:
+        title = re.search(title_re, tip["content"], re.RegexFlag.MULTILINE).group("title").replace("<", "&lt;").replace(">", "&gt;")
+
+        link = tip["short_path"]
+        md = markdown.markdown(f"<div markdown=1>{tip['content']}</div>", extensions=["extra", "codehilite"], output_format="xhtml")
+        md = md.replace("<details open>", "<details open=true>").replace("<", "&lt;").replace(">", "&gt;")
+
+        xml += f"""<item>
+            <title>{title}</title>
+            <link>{url}{link}</link>
+            <guid>{url}{link}</guid>
+            <pubDate>{date}</pubDate>
+            <description>{md}</description>
+        </item>\n"""
+    return xml
+
+
+def main():
+    tips = []
+
+    for file in glob.glob("tips/*.md"):
+        path = pathlib.Path(file)
+        tips.append({
+            "content": path.read_text(encoding="utf-8"),
+            "short_path": path.name,
+        })
+
+    xml = gen_feed(tips, "https://github.com/tip-of-the-week/cpp/blob/master/tips/")
+    template = pathlib.Path("feed.template.xml")
+    new_content = template.read_text().replace("<!-- START FEED -->", xml)
+    pathlib.Path("feed.xml").write_text(new_content)
+
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
This pull request adds:

* a github workflow that triggers on push to master, to generate an RSS feed that is pushed to master (this won't create infinite commits thanks to the update commit being prefixed by `[no ci]`)
* a script that parses the markdown tips to html to generate an xml rss feed
* a xml rss template, to be modified to your liking