### PR TITLE
Bumping github-actions-x/commit version to 2.9

### DIFF
--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -25,7 +25,7 @@ jobs:
       - run: python rss_generator.py
 
       - name: push
-        uses: github-actions-x/commit@v2.8
+        uses: github-actions-x/commit@v2.9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           push-branch: 'master'


### PR DESCRIPTION
As per https://github.com/github-actions-x/commit/issues/30, /github/workspace isn't a safe directory anymore, preventing the push

Bumping to 2.9 fixes the problem