### PR TITLE
Setting specific write permissions for the workflow

### DIFF
--- a/.github/workflows/rss.yml
+++ b/.github/workflows/rss.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      id-token: write
 
     steps:
       - name: checkout


### PR DESCRIPTION
Adding write permission to the workflow seems to fix the push permission issue