### PR TITLE
Fixes order of the tips, their date, links formatting, removes empty p blocks

### DIFF
--- a/rss_generator.py
+++ b/rss_generator.py
@@ -5,24 +5,47 @@ import re
 import sys
 import glob
 import pathlib
-import datetime
+from datetime import datetime
 import markdown
 
 
+def sanitize(text: str) -> str:
+    return text.replace("<", "&lt;").replace(">", "&gt;")
+
+
 def gen_feed(tips, url):
-    date = datetime.datetime.now().strftime("%a, %d %b %Y %H:%M:%S GMT")
     title_re = r"\* +(\*\*)?(?P<title>(?(1).+(?<!\*\*)|.+))(?(1)\*\*$|$)"
+    link_re = r"(?P<link>(?<!\[|\()https?://[\w\./\?&=\-\+#:,;%]+)"
 
     xml = ""
     for tip in tips:
-        title = re.search(title_re, tip["content"], re.RegexFlag.MULTILINE).group("title").replace("<", "&lt;").replace(">", "&gt;")
-
         link = tip["short_path"]
-        md = markdown.markdown(f"<div markdown=1>{tip['content']}</div>", extensions=["extra", "codehilite"], output_format="xhtml")
-        md = md.replace("<details open>", "<details open=true>").replace("<", "&lt;").replace(">", "&gt;")
+        tip_num = link.replace(".md", "")
+
+        date = datetime.fromtimestamp(tip["pub_date"]).strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        title = re.search(title_re, tip["content"], re.RegexFlag.MULTILINE).group("title")
+        title = sanitize(title)
+
+        content = tip["content"]
+        updated = content
+        for match in re.finditer(link_re, content):
+            naked_link = match.group("link")
+            updated = updated.replace(naked_link, f"[{naked_link}]({naked_link})")
+
+        # TODO: find a way to colorize the code, the documentation advise to have custom css
+        # The classes should already have been applied to the code thanks to extension 'codehilite'
+        md = markdown.markdown(
+                f"<div markdown=1>{updated}</div>",
+                extensions=["extra", "codehilite", "nl2br"],
+                output_format="xhtml"
+        )
+        md = md.replace("<p></p>", "")
+        md = md.replace("<details open>", "<details open=true>")
+        md = "<![CDATA[ %s]]>" % md
 
         xml += f"""<item>
-            <title>{title}</title>
+            <title>{tip_num} - {title}</title>
             <link>{url}{link}</link>
             <guid>{url}{link}</guid>
             <pubDate>{date}</pubDate>
@@ -33,12 +56,14 @@ def gen_feed(tips, url):
 
 def main():
     tips = []
+    files = sorted(glob.glob("tips/*.md"), reverse=True)
 
-    for file in glob.glob("tips/*.md"):
+    for file in files:
         path = pathlib.Path(file)
         tips.append({
             "content": path.read_text(encoding="utf-8"),
             "short_path": path.name,
+            "pub_date": path.lstat().st_ctime,
         })
 
     xml = gen_feed(tips, "https://github.com/tip-of-the-week/cpp/blob/master/tips/")

--- a/rss_generator.py
+++ b/rss_generator.py
@@ -29,9 +29,12 @@ def gen_feed(tips, url):
 
         content = tip["content"]
         updated = content
+        links_seen = set()
         for match in re.finditer(link_re, content):
             naked_link = match.group("link")
-            updated = updated.replace(naked_link, f"[{naked_link}]({naked_link})")
+            if naked_link not in links_seen:
+                updated = updated.replace(naked_link, f"[{naked_link}]({naked_link})")
+                links_seen.add(naked_link)
 
         # TODO: find a way to colorize the code, the documentation advise to have custom css
         # The classes should already have been applied to the code thanks to extension 'codehilite'


### PR DESCRIPTION
This pull request fixes various problems with the RSS feed generation such as:
- the order of the tips, which are now from the most recent to the oldest
- links were not properly converted to `<a href=...>` nodes
- the date for each item was the CI date and not the article date
- empty `<p>` blocks were generated by the markdown converter because of the html/markdown mix ; this is fixed by removing them explicitly during the feed generation

Code is still not highlighted, though I don't feel this is a huge problem for now, as it would mean we need to add a lot of css to each item.

Currently the generated feed is 1.3MB, about 34k lines ; every tip is included. Maybe we should shrunk it down to the first 100 tips?

I'm open to any suggestions to enhance this feed