### PR TITLE
fix documentation formatting

### DIFF
--- a/docs/cpp17_vs_cpp20/fixed_string.md
+++ b/docs/cpp17_vs_cpp20/fixed_string.md
@@ -5,16 +5,17 @@
   ```
 
   C++17 via gnu-extension
+  
   ```cpp
   template<class T, T... Cs>
   constexpr auto operator""_cs() { return ct_string<Cs...>{}; }
-
-  ```
+  
   template<class> struct foo {};
   foo<decltype("bar"_cs)>;
   ```
 
   C++20 via fixed_string
+
   ```cpp
   template <std::size_t N>
   struct fixed_string final {


### PR DESCRIPTION
Just an extra "```" creating formatting issues