### PR TITLE
Solution to tip 357: Add flat_map/map/unordered_map performance benchmark

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -10,7 +10,7 @@
             <title>357 - Did you know that C++23 added standard support for `flat_map`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/357.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/357.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -44,13 +44,91 @@
 </li>
 </ul>
 </details></p>
+</details><details><summary>Solutions</summary>
+<pre class="codehilite"><code class="language-cpp">constexpr int N = 2048;
+
+template &lt;template &lt;class...&gt; typename MapType&gt;
+constexpr auto get_values() {
+    MapType&lt;int, int&gt; ret;
+    for (auto i = 0; i &lt; N; ++i) {
+        ret.emplace(std::pair{i, i});
+    }
+    return ret;
+}
+
+const auto values = get_values&lt;std::map&gt;();
+void FlatMapInsertion(benchmark::State&amp; state) {
+    stdext::flat_map&lt;int, int&gt; m;
+    for (auto _ : state) {
+        state.PauseTiming();
+        m.clear();
+        state.ResumeTiming();
+        m.insert(values.cbegin(), values.cend());
+    }
+}
+
+void MapInsertion(benchmark::State&amp; state) {
+    std::map&lt;int, int&gt; m;
+    for (auto _ : state) {
+        state.PauseTiming();
+        m.clear();
+        state.ResumeTiming();
+        m.insert(values.cbegin(), values.cend());
+    }
+}
+
+void UnorderedMapInsertion(benchmark::State&amp; state) {
+    std::unordered_map&lt;int, int&gt; m;
+    for (auto _ : state) {
+        state.PauseTiming();
+        m.clear();
+        state.ResumeTiming();
+        m.insert(values.cbegin(), values.cend());
+    }
+}
+
+void FlatMapLookup(benchmark::State&amp; state) {
+    const auto m = get_values&lt;stdext::flat_map&gt;();
+    for (auto _ : state) {
+        for (auto i = 0; i &lt; N; ++i) {
+            auto is_present = m.contains(i);
+            benchmark::DoNotOptimize(is_present);
+        }
+    }
+}
+
+void MapLookup(benchmark::State&amp; state) {
+    const auto m = get_values&lt;std::map&gt;();
+    for (auto _ : state) {
+        for (auto i = 0; i &lt; N; ++i) {
+            auto is_present = m.contains(i);
+            benchmark::DoNotOptimize(is_present);
+        }
+    }
+}
+
+void UnorderedMapLookup(benchmark::State&amp; state) {
+    const auto m = get_values&lt;std::unordered_map&gt;();
+    for (auto _ : state) {
+        for (auto i = 0; i &lt; N; ++i) {
+            auto is_present = m.contains(i);
+            benchmark::DoNotOptimize(is_present);
+        }
+    }
+}
+</code></pre>
+
+<blockquote>
+<p><a href="https://quick-bench.com/">https://quick-bench.com/</a>q/6MCXQDX5VGG2FOt0sO8TWjwhz9A</p>
+</blockquote>
+</details></p>
 </div>]]></description>
         </item>
 <item>
             <title>356 - Did you know that C++20's `no_unique_address` can be used to find unique types?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/356.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/356.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -146,7 +224,7 @@ constexpr auto is_unique = sizeof(S&lt;Ts...&gt;) == 1;
             <title>355 - Did you know that C++20 added constinit keyword?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/355.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/355.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -190,7 +268,7 @@ auto fn() { return var; }
             <title>354 - Did you know that C++23 added range `string_view` constructor?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/354.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/354.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -250,7 +328,7 @@ struct buffer {
             <title>353 - Did you know that the underlying visit implementation of std::visit has changed since GCC12+, Clang15+?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/353.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/353.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -360,7 +438,7 @@ constexpr decltype(auto) visit(F&amp;&amp; f, V&amp;&amp; v) {
             <title>352 - Did you know about C++26 proposal - `variadic friends`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/352.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/352.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -457,7 +535,7 @@ class MyClass {
             <title>351 - Did you know about C++26 proposal - `inplace_vector`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/351.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/351.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -574,7 +652,7 @@ class inplace_vector {
             <title>350 - Did you know about C++26 proposal - Aggregates are named tuples?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/350.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/350.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -649,7 +727,7 @@ constexpr auto get(DoesNotHaveGetConcept auto s) {
             <title>349 - Did you know that C++26 added new SI prefixes?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/349.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/349.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -709,7 +787,7 @@ static_assert(std::femto{} * std::exa{} == std::kilo{});
             <title>348 - Did you know that C++26 changed arithmetic overloads of std::to_string and std::to_wstring to use std::format?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/348.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/348.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -783,7 +861,7 @@ static_assert(std::femto{} * std::exa{} == std::kilo{});
             <title>347 - Did you know that C++26 added more constexpr for &lt;cmath&gt; and &lt;complex&gt;?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/347.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/347.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <p>*** <strong>Did you know that C++26 added more constexpr for <cmath> and <complex>?</strong></p>
@@ -850,7 +928,7 @@ static_assert(123 == 123_number);
             <title>346 - Did you know that C++26 added testing for success or failure of &lt;charconv&gt; functions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/346.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/346.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -918,7 +996,7 @@ static_assert(!fmt_error);
             <title>345 - Did you know that C++26 allows constexpr cast from `void*`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/345.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/345.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1004,7 +1082,7 @@ int main() {
             <title>344 - Did you know that C++26 added `Member visit`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/344.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/344.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1078,7 +1156,7 @@ struct variant : std::variant&lt;Ts...&gt; {
             <title>343 - Did you know that C++26 std.format added formatting pointers ability?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/343.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/343.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1143,7 +1221,7 @@ struct variant : std::variant&lt;Ts...&gt; {
             <title>342 - Did you know that C++26 added 'A nice placeholder with no name'?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/342.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/342.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1219,7 +1297,7 @@ template&lt;auto _&gt; auto nttp() {}
             <title>341 - Did you know that C++26 added user-generated static_assert messages?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/341.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/341.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1276,7 +1354,7 @@ constexpr auto format(const string&lt;Cs...&gt; fmt, auto&amp;&amp;... args) {
             <title>340 - Did you know that C++26 added bind front and back to NTTP callables?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/340.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/340.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1334,7 +1412,7 @@ int main() {
             <title>339 - Did you know that C++26 added `@, $, and `` to the basic character set?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/339.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/339.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1374,7 +1452,7 @@ auto id = @kris;
             <title>338 - Did you know about C++20 `std::next_permutation` algorithm?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/338.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/338.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1559,7 +1637,7 @@ constexpr auto invoke(auto fn, auto... ts) -&gt; R {
             <title>337 - Did you know that run-time dispatching over type-list can be implemented many different ways?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/337.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/337.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1682,7 +1760,7 @@ constexpr auto dispatch(const int id, const T&amp; data, const TExpr&amp; expr) 
             <title>336 - Did you know about `gnu::vector_size` extension?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/336.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/336.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1781,7 +1859,7 @@ constexpr auto matmul(v16qi (&amp;A)[N], v16qi (&amp;B)[N], std::int32_t (&amp;C
             <title>335 - Did you know that you can simplify `boost.mp11` API with DSL*?*</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/335.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/335.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -1975,7 +2053,7 @@ static_assert(unique_event_ptrs&lt;foo1, bar1, foo1, foo1, bar1, bar2&gt; ==
             <title>334 - Did you know that C++23 added std::invoke_r?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/334.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/334.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2046,7 +2124,7 @@ static_assert(typeid(unsigned long long) == typeid(call(1ll, 2ull, 3l)));
             <title>333 - Did you know that C++20 added std::span?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/333.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/333.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2123,7 +2201,7 @@ static_assert(15 == sum(s));
             <title>332 - Did you know that in C++ you can generate jump tables at compile-time?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/332.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/332.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2189,7 +2267,7 @@ constexpr auto dispatch(auto n) -&gt; int {
             <title>331 - Did you about C++17 std::index_sequence, std::make_index_sequence?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/331.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/331.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2320,7 +2398,7 @@ constexpr const auto matrix =
             <title>330 - Did you know that C++17 added std::pmr::polymorphic_allocator?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/330.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/330.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2487,7 +2565,7 @@ int main() {
             <title>329 - Did you know about C++ allows to pass Pointer To Member Function via template parameter?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/329.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/329.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2648,7 +2726,7 @@ int main() {
             <title>328 - Did you know that C++23 extended floating-point types?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/328.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/328.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2797,7 +2875,7 @@ auto min_max = [](auto t) {
             <title>327 - Did you know that C++17 added `std::forward_as_tuple` and `std::make_from_tuple` and what’s the difference between them?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/327.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/327.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -2980,7 +3058,7 @@ constexpr auto forward_as_tuple(Ts &amp;&amp;...vs) {
             <title>326 - Did you know that C++23 deprecated std::aligned_storage and std::aligned_union?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/326.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/326.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -3233,7 +3311,7 @@ class container {
             <title>325 - Did you know about `typename erasure` technique (via Strong/Opaque Typedefs) in C++?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/325.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/325.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -3461,7 +3539,7 @@ constexpr auto fn() {
             <title>324 - Did you know about `virtual` inheritance in C++?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/324.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/324.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -3605,7 +3683,7 @@ struct implementation&lt;V&gt; : virtual interface&lt;decltype(V)&gt; {
             <title>323 - Did you know that constexpr is strict about undefined behaviour (UB), object lifetime, etc?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/323.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/323.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -3908,7 +3986,7 @@ static_assert(m_1() == &quot;&quot;);
             <title>322 - Did you know that C++23 added Monadic operations for std::expected?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/322.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/322.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4146,7 +4224,7 @@ std::expected&lt;order_with_id, error&gt; execute(auto&amp; ts, const market_dat
             <title>321 - Did you know that C++23 added support for formatting ranges?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/321.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/321.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4269,7 +4347,7 @@ expect(&quot;[[97], [98, 99]]&quot;s ==
             <title>320 - Did you know about intrisincts to support SIMD (Single Instruction, Multiple Data) instructions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/320.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/320.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4417,7 +4495,7 @@ int main() {
             <title>319 - Did you know that C++11 allows calling functions with reference-to-array parameters from an initializer list?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/319.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/319.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4518,7 +4596,7 @@ consteval auto sum_n(const Lists (&amp;...v)[N]) {
             <title>318 - Did you know that `std::unique_ptr` can be constexpr in C++23?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/318.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/318.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4696,7 +4774,7 @@ function(F) -&gt; function&lt;function_type_t&lt;decltype(&amp;F::operator())&gt
             <title>317 - Did you know that with C++20 you can pass concepts?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/317.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/317.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4848,7 +4926,7 @@ constexpr auto create(auto&amp;&amp; injector) {
             <title>316 - Did you know about `std::rank/std::rank_v` type_trait to get the rank of the array?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/316.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/316.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -4989,7 +5067,7 @@ constexpr auto rank_v = []{
             <title>315 - Did you know about C++20 `is_layout_compatible_v` type_trait?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/315.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/315.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5081,7 +5159,7 @@ constexpr auto count_compatible = (... + std::is_layout_compatible_v&lt;T, Ts&gt
             <title>314 - Did you know that with gnu:C++26 a more parts of static reflection can be emulated?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/314.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/314.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5216,7 +5294,7 @@ template
             <title>313 - Did you know that C++26 added #embed?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/313.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/313.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5362,7 +5440,7 @@ constexpr auto meta_contains =
             <title>312 - Did you know that C++20 added support for Unevaluated asm-declaration in constexpr functions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/312.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/312.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5532,7 +5610,7 @@ int main(int argc, char**) {
             <title>311 - Did you know DRY (Don’t Repeat Yourself) comparisons pattern?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/311.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/311.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5719,7 +5797,7 @@ struct any_of {
             <title>310 - Did you know that C+23 permitts static constexpr variables in constexpr functions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/310.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/310.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5814,7 +5892,7 @@ template&lt;&gt;
             <title>309 - Did you know that C++20 added support for constexpr std::vector?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/309.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/309.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -5938,7 +6016,7 @@ static_assert(std::tuple{2} == filter([] { return std::tuple{1, 2, 3}; }, [](aut
             <title>308 - Did you know that the layout of struct fields will affect its size/alignment?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/308.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/308.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -6497,7 +6575,7 @@ template&lt;class T&gt; constexpr auto is_packed_layout_v= sizeof(T) &lt;=1 || i
             <title>307 - Did you know that C++23 added static operator[]?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/307.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/307.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -6628,7 +6706,7 @@ auto fn(){
             <title>306 - Did you know about if/else hell anti-pattern?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/306.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/306.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -6888,7 +6966,7 @@ int main() {
             <title>305 - Did you know about (rejected) proposal for homogeneous variadic function parameters?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/305.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/305.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -7110,7 +7188,7 @@ auto safe_call(auto fn, auto fmt, ...) {
             <title>304 - Did you know that tuple can be implement just with lambdas?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/304.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/304.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -7504,7 +7582,7 @@ template&lt;class T&gt; [[nodiscard]] constexpr auto get(auto t){
             <title>303 - Did you about typename erasure technique to reduce compilation times with templates?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/303.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/303.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -7619,7 +7697,7 @@ template&lt;class... Ts&gt;
             <title>302 - Did you now that with concepts you can override a type?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/302.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/302.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -7743,7 +7821,7 @@ static_assert(std::is_base_of_v&lt;std::__shared_ptr&lt;int, __gnu_cxx::_S_singl
             <title>301 - Did you now that functions in `&lt;charconv&gt;` are constexpr since C++23?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/301.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/301.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -7934,7 +8012,7 @@ template &lt;int N = 4&gt;
             <title>300 - Did you know that C++23 added support for constexpr std::bitset?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/300.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/300.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -8080,7 +8158,7 @@ template&lt;size_t N&gt;
             <title>299 - Did you know that C++20 concepts can be used to avoid implicit conversions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/299.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/299.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -8237,7 +8315,7 @@ static_assert(not can_invoke_with(foo, int{}, double{}, float{}, float{}));
             <title>298 - Did you know that C++23 added static operator()?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/298.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/298.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -8376,7 +8454,7 @@ constexpr auto count = [] -&gt; int {
             <title>297 - **Did you know that C++20 introduced coroutines?** (co__await)</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/297.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/297.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -8729,7 +8807,7 @@ class parser {
             <title>296 - **Did you know that C++20 introduced coroutines?** (co_yield)</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/296.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/296.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -9343,7 +9421,7 @@ constexpr auto sum = [](auto generator) {
             <title>295 - Did you know that C++23 added `stacktrace` library?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/295.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/295.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -9607,7 +9685,7 @@ template &lt;auto N&gt;
             <title>294 - Did you know that with C++20 (constexpr containers) TMP can be achieved with STL?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/294.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/294.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -9846,7 +9924,7 @@ auto first_or_last_depending_on_size = List | [] (boost::mp::concepts::meta auto
             <title>293 - Did you know that C++17 [[nodiscard]] attribute can be applied not only to function?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/293.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/293.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -10024,7 +10102,7 @@ int main() {
             <title>292 - Did you know about memoized for less types (more compile-time friendly) conditional_t?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/292.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/292.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -10223,7 +10301,7 @@ using conditional_t = typename detail::conditional&lt;B&gt;::template fn&lt;T, F
             <title>291 - Did you know about [[gnu::cold]] function attribute to mark functions which are unlikely to be called?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/291.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/291.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -10905,7 +10983,7 @@ auto test_lambda_abort(bool error) {
             <title>290 - Did you know that lambda expression is guaranteed to have a unique type?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/290.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/290.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -11056,7 +11134,7 @@ template&lt;class T, class U = same, class V = diff&lt;T&gt;&gt;
             <title>289 - Did you know that [[assume]] attribute has been accepted to C++23?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/289.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/289.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -11531,7 +11609,7 @@ struct smart_ptr final {
             <title>288 - Did you know you can pass an array by reference?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/288.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/288.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -11707,7 +11785,7 @@ template &lt;class T, std::size_t sz&gt;
             <title>287 - Did you know that C++23 added `auto(x): decay-copy in the language`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/287.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/287.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -11999,7 +12077,7 @@ namespace cpp23 {
             <title>286 - Did you know that Circle supports Python's extended slice syntax for variadic packs?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/286.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/286.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -12143,7 +12221,7 @@ static_assert(std::tuple{4, 5, 6}  == [](auto... ts) { return std::tuple{ts...[3
             <title>285 - Did you know about C++20 template specialization with concepts?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/285.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/285.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -12283,7 +12361,7 @@ struct foobars&lt;C&lt;fs...&gt;, C&lt;bs...&gt;&gt; {};
             <title>284 - Did you know about C++23 ispanstream - A strstream replacement using span&lt;charT&gt; as buffer?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/284.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/284.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -12531,7 +12609,7 @@ template&lt;class... Ts, auto N&gt;
             <title>283 - Did you know that C++23 added `ranges::to` (conversion from ranges to containers)?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/283.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/283.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -12872,7 +12950,7 @@ namespace test::stl {
             <title>282 - Did you know about introduced in C++20 `object concepts`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/282.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/282.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -13448,7 +13526,7 @@ static_assert(not std::regular&lt;not_regular&gt;);
             <title>281 - Did you know about gtest.gmock mocking framework?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/281.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/281.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -13637,7 +13715,7 @@ struct mock_on : ::testing::StrictMock&lt;mock&lt;TEvents&gt;&gt;...{
             <title>280 - Did you know about use cases for type-based `reserved` decorator?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/280.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/280.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -13993,7 +14071,7 @@ struct reserved : T {
             <title>279 - Did you know that C++20 made `std::string` constexpr?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/279.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/279.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -14084,7 +14162,7 @@ static_assert(&quot;abc&quot;s == concat([]{return &quot;a&quot;s;}, []{return &
             <title>278 - Did you know that C++23 added Literal Suffix for (signed) size_t?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/278.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/278.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -14209,7 +14287,7 @@ int main() {
             <title>277 - Did you know that C++17 structured bindings support to custom classes can be added?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/277.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/277.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -14369,7 +14447,7 @@ using make_index_sequence = typename detail::make_index_sequence&lt;N&gt;::type;
             <title>276 - Did you know that C++23 added `bind_back` to simplify writing higher order functions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/276.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/276.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -14559,7 +14637,7 @@ template &lt;typename ... Args&gt;
             <title>275 - Did you know what is the underlying type of NTTP string aka `fixed_string`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/275.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/275.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -14706,7 +14784,7 @@ using to_string_t = decltype([]&lt;auto... Is&gt;(std::index_sequence&lt;Is...&g
             <title>274 - Did you know about C++23 proposal `Structured Bindings can introduce a Pack`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/274.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/274.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -14940,7 +15018,7 @@ constexpr auto first(auto... args) {
             <title>273 - Did you know that concept can be passed via lambda expression?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/273.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/273.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -15158,7 +15236,7 @@ concept fooable = requires (T t) { t.foo(satisfies&lt;Ts&gt;{}...); };
             <title>272 - **Did you know that C++20 added std::ranges::{all_of, any_of, none_of} algorithms**?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/272.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/272.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -15432,7 +15510,7 @@ template&lt;auto... Values&gt;
             <title>271 - Did you know that C++20 added support for floating point values as non-type template parameters?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/271.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/271.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -15590,7 +15668,7 @@ template&lt;double Epsilon = 0.1&gt;
             <title>270 - Did you know that C++23 added `std::to_underlying`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/270.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/270.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -15908,7 +15986,7 @@ constexpr auto sum_enums = []{
             <title>269 - Did you know about `boost::mp11::mp_with_index`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/269.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/269.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -16223,7 +16301,7 @@ auto vector_to_array(const auto &amp;v, auto f) -&gt; void { return f(ToArray{v}
             <title>268 - Did you know that C++20 added `std::erase_if` for std::map and std::vector?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/268.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/268.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -16536,7 +16614,7 @@ template &lt;class... Ts&gt;
             <title>267 - Did you know that C++23 added `std::unreachable`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/267.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/267.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -16726,7 +16804,7 @@ constexpr auto switch_id(const auto id) {
             <title>266 - Did you know wrapping an unqualified function name in parentheses suppresses argument-dependent lookup?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/266.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/266.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -16809,7 +16887,7 @@ struct foo {};
             <title>265 - Did you know that C++23 added Attributes on Lambda-Expressions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/265.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/265.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -16871,7 +16949,7 @@ int main() {
             <title>264 - Did you know that C++20 added `__VA_OPT__` for comma omission and comma deletion?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/264.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/264.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -16938,7 +17016,7 @@ int main() {
             <title>263 - Did you know that C++23 added std::byteswap to swap bytes?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/263.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/263.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -17240,7 +17318,7 @@ auto make_output = [](auto x){
             <title>262 - Did you know that type_info equality operator is constexpr in C++23?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/262.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/262.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -17451,7 +17529,7 @@ consteval bool compare_types(){
             <title>261 - Did you know that C++23 added Monadic operations for std::optional?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/261.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/261.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -17588,7 +17666,7 @@ std::optional&lt;order_with_id&gt; execute(auto&amp; ts, const market_data&amp; 
             <title>260 - Did you know that C++23 added std::move_only_function?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/260.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/260.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -17659,7 +17737,7 @@ int main() {
             <title>259 - Did you know that static reflection supports introspecting constructors?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/259.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/259.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -17849,7 +17927,7 @@ private:
             <title>258 - Did you know that static reflection can be used to invoke functions with named parameters?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/258.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/258.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -17958,7 +18036,7 @@ int main() {
             <title>257 - Did you know that static reflection can be used to implement row polymorphism?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/257.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/257.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -18175,7 +18253,7 @@ struct rows : TRows... {
             <title>256 - Did you know that static reflection proposal for C++2X has mirror/value based interface?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/256.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/256.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -18364,7 +18442,7 @@ auto to_string(const T&amp; t) {
             <title>255 - Did you know that static reflection proposal for C++2X can reflect functions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/255.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/255.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -18705,7 +18783,7 @@ template&lt;class T&gt; auto to_string() {
             <title>254 - Did you know about static reflection proposal for C++2X?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/254.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/254.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -19010,7 +19088,7 @@ template &lt;class T&gt;
             <title>253 - Did you know that C++20 extends support for data time utilities?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/253.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/253.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -19082,7 +19160,7 @@ static_assert(24d / November/ 2022 == sys_days{2022y / November/ Thursday[4]} /*
             <title>252 - **Did you know that C++23 added basic_string::resize_and_overwrite**?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/252.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/252.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -19250,7 +19328,7 @@ int main() {
             <title>251 - Did you know that C++20 added `type_identity` which implements the identity metafunction?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/251.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/251.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -19372,7 +19450,7 @@ static_assert(sizeof(int) + sizeof(float) + sizeof(char) == overload_args_sum((n
             <title>250 - Did you know about methods to access the last element of variadic pack...?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/250.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/250.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -19667,7 +19745,7 @@ constexpr auto nth_element( auto ...  args )
             <title>249 - Did you know that C++23 allows extended init-statement with alias-declaration in the for loop?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/249.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/249.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -19811,7 +19889,7 @@ auto print(std::ostream&amp; os, auto... args) -&gt; std::ostream&amp; {
             <title>248 - Did you know that CRTP can be implemented with C++23 `Deducing this`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/248.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/248.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -20036,7 +20114,7 @@ auto get(const auto &amp;self) { return self.get(); }
             <title>247 - Did you know that `Deducing this` proposal has been voted out into C++23?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/247.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/247.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -20182,7 +20260,7 @@ static_assert(6 == sum(2, 3, 1));
             <title>246 - Did you know that C++11 added a numeric literal operator template?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/246.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/246.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -20441,7 +20519,7 @@ template &lt;char... Cs&gt;
             <title>245 - Did you know about C++2X proposal to add Multidimensional subscript operator?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/245.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/245.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -20719,7 +20797,7 @@ class mdarray{
             <title>244 - Did you know about compiler predefined macros assosicated with the compilation date/time?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/244.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/244.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -20910,7 +20988,7 @@ consteval auto strparse( T arg) -&gt; int
             <title>243 - Did you know about C++2X `Pattern matching using is and as` proposal?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/243.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/243.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -21081,7 +21159,7 @@ int main() {
             <title>242 - Did you know that ANSI/ISO C++ conforming programs must not rely on a maximum template depth greater than 17 (changed to 1024 in C++11)?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/242.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/242.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -21306,7 +21384,7 @@ struct data : TArgs... {<br />
             <title>241 - Did you know about different ways of accessing C-style arrays by index?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/241.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/241.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -21456,7 +21534,7 @@ constexpr auto sum_n(const auto&amp; array) {
             <title>240 - Did you know that `using-declarator` can be used to manipulate the overload set?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/240.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/240.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -21677,7 +21755,7 @@ auto sum_prices(Proc&amp;&amp; ... proc) {
             <title>239 - Did you know that Circle Meta-model allows to convert string to a type?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/239.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/239.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -21788,7 +21866,7 @@ constexpr auto strings_to_tuple(Ts ...) {
             <title>238 - Did you know that Circle Meta-model allows for applying `normal` STL for operations on @meta types?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/238.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/238.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -21986,7 +22064,7 @@ constexpr auto calls_verify_types(auto expected, auto given) {
             <title>237 - Did you know about C++2X proposal for the Circle Meta-model for compilation-time meta-programming?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/237.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/237.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -22141,7 +22219,7 @@ template&lt;class T&gt; auto to_tuple_with_names(const T&amp; t){
             <title>236 - Did you know about `__builtin_dump_struct` clang-extension which can nicely print a struct?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/236.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/236.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -22522,7 +22600,7 @@ template&lt;class T&gt; [[nodiscard]] auto to_tuple_with_names(const T&amp; t) {
             <title>235 - Did you know that C++20 `[[no_unique_address]]` can be used to implement lazy/fast/memory efficient views?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/235.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/235.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -22704,7 +22782,7 @@ template &lt;class T&gt;
             <title>234 - Did you know about function-try-block and that exceptions caught inside that block are implicitly rethrown?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/234.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/234.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -22820,7 +22898,7 @@ struct foo : Ts... {
             <title>233 - Did you know that C++20 made `typename` more optional?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/233.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/233.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -22900,7 +22978,7 @@ auto f8(auto t) -&gt; decltype(t)::type;
             <title>232 - Did you know that different overloads can have different specifiers?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/232.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/232.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -23003,7 +23081,7 @@ consteval auto f(auto... values) requires (sizeof...(values) &gt; 1) { return (.
             <title>231 - Did you know about C++17 variadic using declaration?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/231.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/231.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -23192,7 +23270,7 @@ struct handler final : on_method&lt;Ts&gt;... {
             <title>230 - Did you know that C++23 added `if consteval`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/230.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/230.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -23305,7 +23383,7 @@ constexpr auto add_or_sub = [](const auto... args) {
             <title>229 - Did you know about python's named tuples?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/229.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/229.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -23573,7 +23651,7 @@ struct namedtuple{
             <title>228 - Did you know that C++ allows accessing private members with friend injection?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/228.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/228.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -23778,7 +23856,7 @@ EXPOSE_MEMBER_AND_THEN_GO_THINK_ABOUT_WHAT_YOU_HAVE_DONE(business::messages, tra
             <title>227 - Did you know that `std::variant` become valueless by exception?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/227.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/227.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -24118,7 +24196,7 @@ int main() {
             <title>226 - Did you know about C++23 feature which adds support for inheriting from std::variant?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/226.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/226.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -24381,7 +24459,7 @@ const auto print_id = [] (auto&amp; os) {
             <title>225 - Did you know about C++23 feature which removes unnecessary ()’s from C++ lambdas?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/225.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/225.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -24450,7 +24528,7 @@ const auto print_id = [] (auto&amp; os) {
             <title>224 - Did you know that the JSON standard does not specify that the insertion order of object elements should be preserved?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/224.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/224.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -24724,7 +24802,7 @@ constexpr auto to_json(std::tuple&lt; named&lt;T&gt; ... &gt; const &amp; arg)
             <title>223 - Did you know about the proposal to add json support to the standard library?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/223.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/223.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -24918,7 +24996,7 @@ template&lt;class ...T&gt; constexpr auto to_json(const std::tuple&lt;named&lt;T
             <title>222 - Did you know that C++23 added `contains` function to `string_view`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/222.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/222.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -25120,7 +25198,7 @@ consteval auto values(auto in, auto str) {
             <title>221 - Did you know that with Automatic DI production wiring can be overwritten for integration testing?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/221.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/221.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -25275,7 +25353,7 @@ constexpr auto create(auto&amp;&amp; production, const TFakes&amp;... fakes) -&g
             <title>220 - Did you know that with Automatic DI one can control how dependencies are being created?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/220.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/220.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -25486,7 +25564,7 @@ int main() {
             <title>219 - Did you know about Automatic Dependency Injection libraries such as DI?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/219.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/219.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -26136,7 +26214,7 @@ int main() {
             <title>218 - Did you know about different ways of constructor Dependency Injection?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/218.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/218.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -26666,7 +26744,7 @@ bdd::gherkin::steps steps = [](auto&amp; steps) {
             <title>217 - Did you know the difference between fakes, stubs, mocks?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/217.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/217.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -27180,7 +27258,7 @@ bdd::gherkin::steps steps = [](auto&amp; steps) {
             <title>216 - Did you know that you can inject singletons to improve testability?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/216.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/216.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -27599,7 +27677,7 @@ int main() {
             <title>215 - Did you know C++2X Pattern Matching can be used for run-time dispatching?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/215.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/215.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -27905,7 +27983,7 @@ struct sm {
             <title>214 - Did you know about variadic aggregate initialization?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/214.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/214.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -28306,7 +28384,7 @@ private:
             <title>213 - Did you know that mapping types to values is a simple way to transition from compile-time to run-time space?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/213.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/213.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -28675,7 +28753,7 @@ struct sm {
             <title>212 - Did you know that lambdas are const by default but can be mutable and keep state?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/212.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/212.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -29296,7 +29374,7 @@ auto sum_prices = [sum = std::size_t{}](std::string_view buffer) mutable -&gt; s
             <title>211 - Did you know about C++2X Pattern Matching proposal?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/211.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/211.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -29738,7 +29816,7 @@ auto sum_prices = [sum = std::size_t{}](std::string_view buffer) mutable -&gt; s
             <title>210 - Did you know about `Design By Introspection`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/210.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/210.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -29998,7 +30076,7 @@ private:
             <title>209 - Did you know about `Policy Based Design`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/209.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/209.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -30208,7 +30286,7 @@ struct foo {
             <title>208 - Did you know that default template arguments can be explored with template template arguments?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/208.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/208.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -30518,7 +30596,7 @@ using rebind_defaults_t = detail::rebind&lt;T, type_defaults_t&lt;T&gt;, TBinds.
             <title>207 - Did you know about the proposal to add constexpr function parmaters?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/207.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/207.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -30816,7 +30894,7 @@ template&lt;class...Args&gt; struct tuple : std::tuple&lt;Args...&gt; {
             <title>206 - Did you know about proposal to add support for recursive lambdas?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/206.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/206.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -30994,7 +31072,7 @@ constexpr auto sum_years = [](const auto year) {
             <title>205 - Did you know that C++20 `std::to_array` supports creating from string literals?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/205.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/205.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -31144,7 +31222,7 @@ constexpr const auto xmas_tree = tree&lt;Size, T&gt;();
             <title>204 - Did you know that you can implement a compile-time map with C++?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/204.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/204.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -31406,7 +31484,7 @@ constexpr unpack&lt;T, pack&lt;Ts...&gt;, &quot;one&quot;, &quot;two&quot;&gt; m
             <title>203 - Did you know that in C++ `char`, `signed char` and `unsigned char` are 3 different types?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/203.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/203.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -31744,7 +31822,7 @@ static_assert(not [](auto... args) { return requires { foo(args...); }; }((signe
             <title>202 - Did you know that C++20 added `Using Enum` which introduces the enumerator names of the named enumeration as if by a using-declaration for each enumerator?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/202.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/202.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -31881,7 +31959,7 @@ static_assert(is_enum_in_scope&lt;InScope&gt;([](auto e){ return requires { e.ec
             <title>201 - Did you know that `sizeof` operator can be used for efficient math computation?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/201.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/201.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -32030,7 +32108,7 @@ constexpr auto exponent = []&lt;auto... Ns&gt;(std::index_sequence&lt;Ns...&gt;)
             <title>200 - Did you know that C++23 added `is_scoped_enum` type trait to detect whether an enum is scoped?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/200.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/200.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -32175,7 +32253,7 @@ concept any_enum = std::is_enum_v&lt;T&gt; and std::is_convertible_v&lt;T, std::
             <title>199 - Did you know about proposal to introduce constexpr ternary operator?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/199.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/199.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -32625,7 +32703,7 @@ constexpr auto operator or(const TCompare&amp; lhs, const auto&amp; false_in)
             <title>198 - Did you know about different ways of iterating over objects?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/198.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/198.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -32956,7 +33034,7 @@ auto iterate(std::vector&lt;T&gt; v, auto&amp;&amp; expr) -&gt; void {
             <title>197 - Did you know that Lambdas in Unevaluated Context combined with Template Constraints (Concepts) can be used with types?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/197.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/197.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33100,7 +33178,7 @@ using copy_if = detail::type_filter&lt;TExpr, Ts...&gt;;
             <title>196 - Did you know that Lambdas in Unevaluated Context combined with Immediately Invoked Function Expressions (IIFE) can be used to simplify Template Meta-Programming?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/196.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/196.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33219,7 +33297,7 @@ constinit auto add_pointer = type_list&lt;decltype([](auto v)
             <title>195 - Did you know that C++20 added support for `[[no_unique_address]]` attribute?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/195.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/195.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33342,7 +33420,7 @@ struct [[gnu::packed]] foo {
             <title>194 - Did you know about C++23 proposal to add `views::enumerate`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/194.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/194.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33526,7 +33604,7 @@ struct enumerate {
             <title>193 - Did you know that C++20 added support for `constexpr new`?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/193.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/193.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33659,7 +33737,7 @@ struct unique_ptr {
             <title>192 - Did you know about `std::expected` proposal for error handling?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/192.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/192.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33858,7 +33936,7 @@ struct expected : std::optional&lt;T&gt;
             <title>191 - Did you know that expression evaluation order is not specified?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/191.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/191.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -33958,7 +34036,7 @@ int main() {
             <title>190 - Did you know that C++20 added `ostream_joiner` that writes successive objects into the basic_ostream separated by a delimiter?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/190.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/190.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -34151,7 +34229,7 @@ public:
             <title>189 - Did you know that Compile Time Regular Expressions support extracting matches?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/189.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/189.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -34404,7 +34482,7 @@ constexpr auto parse_args&lt;empty&gt;(std::string_view input) -&gt; empty {
             <title>188 - Did you know about proposal to add Compile Time Regular Expressions?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/188.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/188.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -34765,7 +34843,7 @@ static_assert(ctre::match&lt;&quot;.*&quot;&gt;(&quot;hello world&quot;));
             <title>187 - Did you know that C++17 made exception specifications be part of the type system?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/187.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/187.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -34974,7 +35052,7 @@ constexpr auto function_pointer_maker() -&gt; decltype(&amp;T::template operator
             <title>186 - Did you know Non-Type Template Parameters (NTTP) with User-Defined Literals (UDL) can be used to get compile-time strings?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/186.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/186.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -35168,7 +35246,7 @@ constexpr auto fixed_format(auto format, auto... args) {
             <title>185 - Did you know about the proposal to make `printf` compile-time safe and with named arguments?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/185.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/185.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -35447,7 +35525,7 @@ constexpr auto has_valid_args(auto fmt, auto... args) {
             <title>184 - **Did you know that you can customize formatter for your classes with `std::format`**?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/184.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/184.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -35697,7 +35775,7 @@ struct fmt::formatter&lt;foo&lt;Ts...&gt;&gt; {
             <title>183 - Did you know that `Formatted output` has been accepted into C++20?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/183.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/183.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>
@@ -35893,7 +35971,7 @@ id_continue       ::=  id_start | digit
             <title>182 - Did you know about the proposal to add Non-terminal variadic template parameters?</title>
             <link>https://github.com/tip-of-the-week/cpp/blob/master/tips/182.md</link>
             <guid>https://github.com/tip-of-the-week/cpp/blob/master/tips/182.md</guid>
-            <pubDate>Wed, 22 Nov 2023 17:57:04 GMT</pubDate>
+            <pubDate>Mon, 27 Nov 2023 12:14:02 GMT</pubDate>
             <description><![CDATA[ <div>
 <p><details open=true><summary>Info</summary>
 <ul>

--- a/tips/357.md
+++ b/tips/357.md
@@ -25,3 +25,83 @@ int main() {
     * https://quick-bench.com/
 
 </p></details>
+
+</p></details><details><summary>Solutions</summary><p>
+
+```cpp
+constexpr int N = 2048;
+
+template <template <class...> typename MapType>
+constexpr auto get_values() {
+    MapType<int, int> ret;
+    for (auto i = 0; i < N; ++i) {
+        ret.emplace(std::pair{i, i});
+    }
+    return ret;
+}
+
+const auto values = get_values<std::map>();
+void FlatMapInsertion(benchmark::State& state) {
+    stdext::flat_map<int, int> m;
+    for (auto _ : state) {
+        state.PauseTiming();
+        m.clear();
+        state.ResumeTiming();
+        m.insert(values.cbegin(), values.cend());
+    }
+}
+
+void MapInsertion(benchmark::State& state) {
+    std::map<int, int> m;
+    for (auto _ : state) {
+        state.PauseTiming();
+        m.clear();
+        state.ResumeTiming();
+        m.insert(values.cbegin(), values.cend());
+    }
+}
+
+void UnorderedMapInsertion(benchmark::State& state) {
+    std::unordered_map<int, int> m;
+    for (auto _ : state) {
+        state.PauseTiming();
+        m.clear();
+        state.ResumeTiming();
+        m.insert(values.cbegin(), values.cend());
+    }
+}
+
+void FlatMapLookup(benchmark::State& state) {
+    const auto m = get_values<stdext::flat_map>();
+    for (auto _ : state) {
+        for (auto i = 0; i < N; ++i) {
+            auto is_present = m.contains(i);
+            benchmark::DoNotOptimize(is_present);
+        }
+    }
+}
+
+void MapLookup(benchmark::State& state) {
+    const auto m = get_values<std::map>();
+    for (auto _ : state) {
+        for (auto i = 0; i < N; ++i) {
+            auto is_present = m.contains(i);
+            benchmark::DoNotOptimize(is_present);
+        }
+    }
+}
+
+void UnorderedMapLookup(benchmark::State& state) {
+    const auto m = get_values<std::unordered_map>();
+    for (auto _ : state) {
+        for (auto i = 0; i < N; ++i) {
+            auto is_present = m.contains(i);
+            benchmark::DoNotOptimize(is_present);
+        }
+    }
+}
+```
+
+> https://quick-bench.com/q/6MCXQDX5VGG2FOt0sO8TWjwhz9A
+
+</p></details>


### PR DESCRIPTION
Got this benchmark working after some setbacks:

1. Quickbench does not support URL inclusion, so the header file had to be manually pasted into the benchmark. 
2. Quickbench limits code size to around ~600 lines, so the `stdext::flat_map` implementation had to be trimmed to use minimal amount of code.
3. There was an error on quickbench when importing code from godbolt: "Unexpected error: please contact website owner" so I contacted to website owner to fix this regression.
4. The benchmark times out with clang/libc++, so I used GCC/libstdc++.
