### PR TITLE
fix typo in code example

### DIFF
--- a/tips/358.md
+++ b/tips/358.md
@@ -41,7 +41,7 @@ constexpr decltype(auto) nth(T0&& p0, Types&&... pack) noexcept
    if constexpr (0 == Index)
        return std::forward<T0>(p0);
    else
-       return nth_value<Index-1>(std::forward<Types>(pack)...);
+       return nth<Index-1>(std::forward<Types>(pack)...);
 }
  
 consteval auto first(auto... ts) {


### PR DESCRIPTION
The markdown code example contains a name `nth_value` which is not defined. This commit aligns the example with the code in https://godbolt.org/z/bc71YxGY1