### PR TITLE
Fix separated spelling in tip text

### DIFF
--- a/tips/184.md
+++ b/tips/184.md
@@ -43,13 +43,13 @@ int main() {
       expect("foo()"sv == fmt::format("{}", foo{}));
     };
 
-    should("format fields seperated by space") = [] {
+    should("format fields separated by space") = [] {
       expect("foo( 1 )"sv == fmt::format("{}", foo{1}));
       expect("foo( 1 2 )"sv == fmt::format("{}", foo{1, 2}));
       expect("foo( 1 2 3 )"sv == fmt::format("{}", foo{1, 2, 3}));
     };
 
-    should("format fields seperated by space with different types") = [] {
+    should("format fields separated by space with different types") = [] {
       expect("foo( Quant Lab )"sv == fmt::format("{}", foo{"Quant", "Lab"}));
       expect("foo( Q 42 B )"sv == fmt::format("{}", foo{'Q', 42, "B"}));
     };


### PR DESCRIPTION
## Summary
- fix `seperated` to `separated` in tip 184 example descriptions

## Testing
- git diff --check